### PR TITLE
fix: update link to Building Codex

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -25,7 +25,7 @@ import { Badge } from '../src/components/Badge'
 
 ## Build and run
 
-For detailed instructions on preparing to build nim-codex see [*Building Codex*](BUILDING.md).
+For detailed instructions on preparing to build nim-codex see [*Building Codex*](https://github.com/codex-storage/nim-codex/blob/master/BUILDING.md).
 
 To build the project, clone it, and run:
 


### PR DESCRIPTION
### Description:
Fix a link to the "Building Codex" which points to the `BUILDING.md` located now in the [codex-storage/nim-codex](https://github.com/codex-storage/nim-codex) repository.


### Related Issue(s):
https://github.com/codex-storage/infra-codex/issues/118


### Changes Included:
- [x] Bugfix  - link to "Building Codex" was updated


### Implementation Details:
As a quick fix we updated just a link and should consider to review documentation later.


### Testing:
Not tested and just link URL was updated.


### Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules