### PR TITLE
Publish Testnet related documentation

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,140 +3,88 @@ sidebar_position: 1
 description: Codex is building a decentralised durability storage engine
 ---
 
-import { Badge } from '../src/components/Badge'
 
-
-# Guides
+## Codex
 
 > The Codex project aims to create a decentralized durability engine that allows persisting data in p2p networks. In other words, it allows storing files and data with predictable durability guarantees for later retrieval.
 
 > WARNING: This project is under active development and is considered pre-alpha.
 
-<Badge className="badge-margin" href="https://opensource.org/licenses/Apache-2.0" imgSrc="https://img.shields.io/badge/License-Apache%202.0-blue.svg" imgAlt="License: Apache"/>
 
-<Badge className="badge-margin" href="https://opensource.org/licenses/MIT" imgSrc="https://img.shields.io/badge/License-MIT-blue.svg" imgAlt="License: MIT"/>
+## Testnet flow and ideas for Codex
+What can you try on our network
 
-<Badge className="badge-margin" href="https://img.shields.io/badge/stability-experimental-orange.svg" imgSrc="https://img.shields.io/badge/stability-experimental-orange.svg" imgAlt="Stability: experimental"/>
-
-<Badge className="badge-margin" href="https://github.com/codex-storage/nim-codex/actions/workflows/ci.yml?query=branch%3Amaster" imgSrc="https://github.com/codex-storage/nim-codex/actions/workflows/ci.yml/badge.svg?branch=master" imgAlt="CI"/>
-
-<Badge className="badge-margin" href="https://codecov.io/gh/codex-storage/nim-codex" imgSrc="https://codecov.io/gh/codex-storage/nim-codex/branch/master/graph/badge.svg?token=XFmCyPSNzW" imgAlt="Codecov"/>
-
-<Badge className="badge-margin" href="https://discord.gg/codex-storage" imgSrc="https://img.shields.io/discord/895609329053474826" imgAlt="Discord" />
-
-
-## Build and run
-
-For detailed instructions on preparing to build nim-codex see [*Building Codex*](https://github.com/codex-storage/nim-codex/blob/master/BUILDING.md).
-
-To build the project, clone it and run:
-```bash
-make update && make
-```
-
-The executable will be placed under the `build` directory under the project root.
-
-Run the client with:
-```bash
-build/codex
-```
+1. **Make storage available** to the Codex network (for storage providers)
+2. Ask the network to **store files** on the Codex
+3. **Run multiple nodes** and try to put on their storage hosts hats
+4. **Spin your own node** and go over the entire installation process
+5. Look at the **speed and performance of the entire user flow** and provide feedback to the team
+6. Try to store large files (2gb or more) and report any potential issue that had
+7. Test how **upload** to the networks works for **small and large files**
+8. **Check the Retrieval flow** for files that are stored on the network + speed to get it back
+9. **General usability test**: provide feedback on the system performance and which steps you found difficult.
 
 
-### CLI options
+## How to get started with Codex and test all of the scenarios we mentioned above
+> It’s really simple - you just need to follow all the steps for our cool [codex-testnet-starter](https://github.com/codex-storage/codex-testnet-starter)
 
-```
-build/codex --help
-Usage:
+### Steps to kick-off and use codex are:
 
-codex [OPTIONS]... command
+**Prerequisites:**
+1. Docker-desktop
+2. Discord + Join our server
+3. Enough tech knowledge to set up a port forwarding in your local network
 
-The following options are available:
-
-     --config-file          Loads the configuration from a TOML file [=none].
-     --log-level            Sets the log level [=info].
-     --metrics              Enable the metrics server [=false].
-     --metrics-address      Listening address of the metrics server [=127.0.0.1].
-     --metrics-port         Listening HTTP port of the metrics server [=8008].
- -d, --data-dir             The directory where codex will store configuration and data..
- -i, --listen-addrs         Multi Addresses to listen on [=/ip4/0.0.0.0/tcp/0].
- -a, --nat                  IP Addresses to announce behind a NAT [=127.0.0.1].
- -e, --disc-ip              Discovery listen address [=0.0.0.0].
- -u, --disc-port            Discovery (UDP) port [=8090].
-     --net-privkey          Source of network (secp256k1) private key file path or name [=key].
- -b, --bootstrap-node       Specifies one or more bootstrap nodes to use when connecting to the network..
-     --max-peers            The maximum number of peers to connect to [=160].
-     --agent-string         Node agent string which is used as identifier in network [=Codex].
-     --api-bindaddr         The REST API bind address [=127.0.0.1].
- -p, --api-port             The REST Api port [=8080].
-     --repo-kind            backend for main repo store (fs, sqlite) [=fs].
- -q, --storage-quota        The size of the total storage quota dedicated to the node [=8589934592].
- -t, --block-ttl            Default block timeout in seconds - 0 disables the ttl [=$DefaultBlockTtl].
-     --block-mi             Time interval in seconds - determines frequency of block maintenance cycle: how
-                            often blocks are checked for expiration and cleanup.
-                            [=$DefaultBlockMaintenanceInterval].
-     --block-mn             Number of blocks to check every maintenance cycle. [=1000].
- -c, --cache-size           The size in MiB of the block cache, 0 disables the cache - might help on slow
-                            hardrives [=0].
-     --persistence          Enables persistence mechanism, requires an Ethereum node [=false].
-     --eth-provider         The URL of the JSON-RPC API of the Ethereum node [=ws://localhost:8545].
-     --eth-account          The Ethereum account that is used for storage contracts [=EthAddress.none].
-     --eth-deployment       The json file describing the contract deployment [=string.none].
-     --validator            Enables validator, requires an Ethereum node [=false].
-     --validator-max-slots  Maximum number of slots that the validator monitors [=1000].
-
-Available sub-commands:
-
-codex initNode
-```
+**Steps to join the Codex network:**
+1. Clone repository
+2. Modify docker-compose file with:
+  a. Your own private key
+  b. Bootstrap-SPR with one from the list
+     ```
+     spr:CiUIAhIhAiJvIcA_ZwPZ9ugVKDbmqwhJZaig5zKyLiuaicRcCGqLEgIDARo8CicAJQgCEiECIm8hwD9nA9n26BUoNuarCEllqKDnMrIuK5qJxFwIaosQtcKdqwYaCwoJBJ_f8zKRAnU6KkcwRQIhAKMczlNPHUIkSw0y_Vi2OTimLQ85DmtUEYcu3-t5EUHTAiAvl9vOs9kDGUUpZwsKpNHUGwauxJFSq1SOqi08OrtycQ
+     spr:CiUIAhIhAyUvcPkKoGE7-gh84RmKIPHJPdsX5Ugm_IHVJgF-Mmu_EgIDARo8CicAJQgCEiEDJS9w-QqgYTv6CHzhGYog8ck92xflSCb8gdUmAX4ya78Q2aWZqwYaCwoJBES39Q2RAnVOKkYwRAIgaCDDf4pbehpubwi7ikQtSs5lgorPTVIDO1N1rKyoDYECIG-xVpaKL5wVGG9WlIbDmjKNHMhV2MibPr7kaWlGaSsr
+     spr:CiUIAhIhA6_j28xa--PvvOUxH10wKEm9feXEKJIK3Z9JQ5xXgSD9EgIDARo8CicAJQgCEiEDr-PbzFr74--85TEfXTAoSb195cQokgrdn0lDnFeBIP0Q_aSZqwYaCwoJBK6Kf1-RAnVEKkcwRQIhALKgBZMCEj7HgUurhln83vaprOB3fKJ-Ys3uBVjc6uErAiAogqNyb8GGmeZYDUouoymll-f4436H1USbpV8VKhW1-Q
+     spr:CiUIAhIhA7E4DEMer8nUOIUSaNPA4z6x0n9Xaknd28Cfw9S2-cCeEgIDARo8CicAJQgCEiEDsTgMQx6vydQ4hRJo08DjPrHSf1dqSd3bwJ_D1Lb5wJ4Qk5-cqwYaCwoJBEDhWZORAnVYKkYwRAIgDo5waIP4k16ygllsQ_F2MkB-k4bNVcKAF0KigACXyGECIF0_F0bKS1rNJ
+6GQju7p2eiIGGn-WTc9wNriNsXkVvyW
+     spr:CiUIAhIhAzZn3JmJab46BNjadVnLNQKbhnN3eYxwqpteKYY32SbOEgIDARo8CicAJQgCEiEDNmfcmYlpvjoE2Np1Wcs1ApuGc3d5jHCqm14phjfZJs4QmKWcqwYaCwoJBKpA-TaRAnViKkYwRAIgOBKHCLY_n9Du7YOPPKYgCjUU8qmXMZ9JTo03cgInhkICIGpH78Ip6JQdL
+eBL7D5XWY82DaBN7tsWUlxV-rHpGiJQ
+     ```
+3. Mint some test-tokens:
+  a. In the discord server, give your public key / eth address to the bot
+  b. Mint some tokens using the bot
+4. You may have to forward the following ports from the docker-compose file:
+    1. Codex Discovery - UDP (8090 by default)
+    2. Codex Listen - TCP (8070 by default)
+    3. Geth Discovery - UDP (8547 by default)
+    4. Geth Listen - TCP (8548 by default)
+5. Start the docker-compose file
+6. Wait until the Geth node is synced
+7. Open the Codex-Frontend in your browser
+8. Rejoice!
 
 
-### Example: Running two Codex clients
+Also keep in mind - we have a new, stunning feature that will help us with user flow and reward them - we call it “**Discord roles for rewards**”
 
- For more information please see [Codex Two-Client Test](https://github.com/codex-storage/nim-codex/blob/master/docs/TWOCLIENTTEST.md).
+**How does it work:**
 
+We can create and config any number of Discord server roles as rewards for testnet participation. The bot can automatically give discord roles to users as they reach certain milestones in the testnet.
 
-### Interacting with the client
+Here are some examples to consider:
 
- The client exposes a REST API that can be used to interact with the clients. These commands could be invoked with any HTTP client, however the following endpoints assume the use of the `curl` command.
+- Hosting:
+    - Fill a slot of any size and duration
+    - Finish a slot of any size and duration
+    - Finish a slot of minimum 256MB and 24h
+- Interacting with the Codex Client:
+    - Post a contract
+    - Post a contract that reaches “Started” state
+    - Post a contract with at least 4 slots, where each slot is at least 256MB, and has a duration of at least 24h, and it reaches “Started” state
 
- For more information about API endpoints please see [api.codex.storage](https://api.codex.storage/).
-
-
-#### `/api/codex/v1/connect/{peerId}`
-
-Connect to a peer identified by its peer id. Takes an optional `addrs` parameter with a list of valid [multiaddresses](https://multiformats.io/multiaddr/). If `addrs` is absent, the peer will be discovered over the DHT.
-
-Example:
-```bash
-curl "127.0.0.1:8080/api/codex/v1/connect/<PEER ID HERE>?addrs=/ip4/127.0.0.1/tcp/8071"
-```
+## [Join Codex Discord to find out more!](https://discord.gg/codex-storage)
 
 
-#### `/api/codex/v1/data/{id}/network`
-Download data identified by a `CID`.
+## Links
 
-Example:
-```bash
-curl 127.0.0.1:8080/api/codex/v1/data/<CID>/network -o <OUTPUT FILE>
-```
-
-
-#### `/api/codex/v1/data`
-
-Upload a file, upon success returns the `CID` of the uploaded file.
-
-Example:
-```bash
-curl -X POST 127.0.0.1:8080/api/codex/v1/data -H "content-type: application/octet-stream" -H "Expect: 100-continue" -T "<FILE PATH>"
-
-```
-
-
-#### `/api/codex/v1/debug/info`
-
-Get useful node info such as its peer id, address, and SPR.
-
-Example:
-```bash
-curl 127.0.0.1:8080/api/codex/v1/debug/info
-```
+ 1. [Building Codex](https://github.com/codex-storage/nim-codex/blob/master/BUILDING.md).
+ 2. [Codex Two-Client Test](https://github.com/codex-storage/nim-codex/blob/master/docs/TWOCLIENTTEST.md).
+ 3. [API endpoints](https://api.codex.storage).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,7 +61,7 @@ const config = {
             label: 'Guides',
           },
           {
-            href: 'https://discord.gg/2NXGrsqmDq',
+            href: 'https://discord.gg/codex-storage',
             label: 'Discord',
           },
           {
@@ -76,7 +76,7 @@ const config = {
         ],
       },
       footer: {
-        copyright: 'Codex @2023<br/>All Rights Reserved.',
+        copyright: 'Codex @2024<br/>All Rights Reserved.',
         links: [
           {
             items: [
@@ -85,7 +85,7 @@ const config = {
                 label: 'Twitter',
               },
               {
-                href: 'https://discord.gg/2NXGrsqmDq',
+                href: 'https://discord.gg/codex-storage',
                 label: 'Discord',
               },
               {


### PR DESCRIPTION
### Description:
Add Testnet information


### Related Issue(s):
https://github.com/codex-storage/infra-codex/issues/125


### Changes Included:
- [ ] Index page is replaced with Testnet related information


### Implementation Details:
We need to publish Testnet related information and guides


### Testing:
- Local deployment via `yarn`
- Netlify should show a preview


### Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules