### PR TITLE
feat: use two deploy branches for CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,6 @@
+#!/usr/bin/env groovy
+library 'status-jenkins-lib@v1.8.8'
+
 pipeline {
   agent { label 'linux' }
 
@@ -13,44 +16,34 @@ pipeline {
   environment {
     GIT_COMMITTER_NAME = 'status-im-auto'
     GIT_COMMITTER_EMAIL = 'auto@status.im'
-    PROD_SITE = 'docs.codex.storage'
-    DEV_SITE  = 'dev-docs.codex.storage'
-    DEV_HOST  = 'jenkins@node-01.do-ams3.sites.misc.statusim.net'
-    SCP_OPTS  = 'StrictHostKeyChecking=no'
   }
 
   stages {
     stage('Install') {
       steps {
-        sh "yarn install"
+        sh 'yarn install'
       }
     }
 
     stage('Build') {
       steps {
-        sh 'yarn build'
-        sh "echo ${env.PROD_SITE} > build/CNAME"
+        script {
+          sh 'yarn build'
+          jenkins.genBuildMetaJSON('build/build.json')
+        }
       }
     }
 
-    stage('Publish Prod') {
-      when { expression { env.GIT_BRANCH ==~ /.*master/ } }
+    stage('Publish') {
       steps {
         sshagent(credentials: ['status-im-auto-ssh']) {
-          sh "ghp-import -p build"
-        }
-      }
-    }
-
-    stage('Publish Devel') {
-      when { expression { env.GIT_BRANCH ==~ /.*develop/ } }
-      steps {
-        sshagent(credentials: ['jenkins-ssh']) {
           sh """
-            rsync -e 'ssh -o ${SCP_OPTS}' -r --delete build/. \
-              ${env.DEV_HOST}:/var/www/${env.DEV_SITE}/
+            ghp-import \
+              -b ${deployBranch()} \
+              -c ${deployDomain()} \
+              -p build
           """
-        }
+         }
       }
     }
   }
@@ -59,3 +52,7 @@ pipeline {
     cleanup { cleanWs() }
   }
 }
+
+def isMasterBranch() { GIT_BRANCH ==~ /.*master/ }
+def deployBranch() { isMasterBranch() ? 'deploy-master' : 'deploy-develop' }
+def deployDomain() { isMasterBranch() ? 'docs.codex.storage' : 'dev-docs.codex.storage' }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ presets: [
 
 This is probably enough in most cases, as the Logos plugins will fill in other configurations related to the specified business unit. If you find any error in the information coming from Logos Plugins, please head over to [Logos Docusaurus Plugins](https://github.com/acid-info/logos-docusaurus-plugins) and create an issue.
 
+## CI/CD
+
+- [CI builds](https://ci.infra.status.im/job/website/job/docs.codex.storage/) `master` and pushes to `deploy-master` branch, which is hosted at <https://codex.storage//>.
+- [CI builds](https://ci.infra.status.im/job/website/job/dev-docs.codex.storage/) `develop` and pushes to `deploy-develop` branch, which is hosted at <https://dev-docs.codex.storage//>.
+
+The hosting is done using [Caddy server with Git plugin for handling GitHub webhooks](https://github.com/status-im/infra-misc/blob/master/ansible/roles/caddy-git).
+
+Information about deployed build can be also found in `/build.json` available on the website.
+
 ## Customization
 
 You can find the instructions on adding more documentation sections, localization, and versioning on the [Docusaurus](https://docusaurus.io/docs) website.


### PR DESCRIPTION
## Description:
This way we have two branches on GitHub that reflect the state of the
website after CI build has finished and pushed.

## Related Issue(s): https://github.com/status-im/infra-misc/issues/278